### PR TITLE
Intall missing canberra dependencies

### DIFF
--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -29,6 +29,8 @@
     - synaptic
     - terminator
     - vim
+    - libcanberra-gtk-module
+    - libcanberra-gtk3-module
 
 - import_tasks: terminator.yml
   become: no


### PR DESCRIPTION
This gets rid of ugly warnings when starting certain applications