### PR TITLE
Remove flatpak software center plugin

### DIFF
--- a/roles/common/tasks/apt.yml
+++ b/roles/common/tasks/apt.yml
@@ -21,7 +21,6 @@
     - openjdk-11-doc
     - flatpak
     - fzf
-    - gnome-software-plugin-flatpak
     - git
     - httpie
     - keepassxc


### PR DESCRIPTION
Ubuntu 20.04 ships with snap store, and flatpak software center plugin
is incompatible with it.